### PR TITLE
fix:fix the bug when forecast data includes todays data

### DIFF
--- a/js/_daily-forecast.js
+++ b/js/_daily-forecast.js
@@ -24,6 +24,8 @@ function createForecastData(data) {
 
   for (const item of data.list) {
     const dateTime = new Date(item.dt_txt);
+    const today = new Date();
+    if (dateTime.getDate() === today.getDate()) continue;
     const date = dateTime.toLocaleDateString(undefined, {
       month: "short",
       day: "numeric",


### PR DESCRIPTION
This bug below happens when you open the app in morning, and forecast data includes today's data.
I fixed it by removing today's data when creating the forecast data.

<img width="770" alt="Screenshot 2023-08-15 at 10 30 04" src="https://github.com/shylabo/weather-app/assets/99339182/1662b9e7-11ea-498b-bbe1-e023641b1a82">

